### PR TITLE
fix: minus temperature is returned as String

### DIFF
--- a/decoder.js
+++ b/decoder.js
@@ -356,7 +356,7 @@ function ttnDataFormat (str) {
             }
         }
         str2 = parseInt(reverseArr.join(""), 2) + 1;
-        return "-" + str2 / 1000;
+        return parseFloat("-" + str2 / 1000);
     }
     return parseInt(str2, 2) / 1000;
 }


### PR DESCRIPTION
The decoder returns Strings instead of Numbers when the temperature goes below zero.

Sample data for minus temperature: `"measurementValue": "-1.6"`

I came across this issue testing the SenseCAP sensor on TTN during a colder night.